### PR TITLE
spelling correction of Gulmi headquater

### DIFF
--- a/database/seeds/DistrictSeeder.php
+++ b/database/seeds/DistrictSeeder.php
@@ -334,7 +334,7 @@ class DistrictSeeder extends Seeder
             [
                 'province_id' => 5,
                 'name' => 'Gulmi',
-                'headquater' => 'Tanghas',
+                'headquater' => 'Tamghas',
                 'area' => 1149
             ],
             [


### PR DESCRIPTION
There was an spelling error in headquarter of Gulmi district. Previously, it was **Tanghas**, Correct one is **Tamghas**. I have corrected that one.