### PR TITLE
duplicate terhathum district removed from province 1 in district table seeder

### DIFF
--- a/database/seeds/DistrictSeeder.php
+++ b/database/seeds/DistrictSeeder.php
@@ -95,12 +95,6 @@ class DistrictSeeder extends Seeder
                 'name' => 'Udayapur',
                 'headquater' => 'Gaighat',
                 'area' => 2063
-            ],
-            [
-                'province_id' => 1,
-                'name' => 'Terathum',
-                'headquater' => 'Myanglung',
-                'area' => 679
             ]
         );
 


### PR DESCRIPTION
Nepal has 77 district but I have found 78 districts in the districts table in the database. Problem was **Terhathum** district was entered twice in the district table seeder for province one. That duplicate leads to 78 districts in Nepal which leads to false statistics. I have removed that duplicate.