### PR TITLE
wrong district province linkup issue fixed

### DIFF
--- a/database/seeds/DistrictSeeder.php
+++ b/database/seeds/DistrictSeeder.php
@@ -136,19 +136,19 @@ class DistrictSeeder extends Seeder
                 'area' => 1180
             ],
             [
-                'province_id' => 1,
+                'province_id' => 2,
                 'name' => 'Siraha',
                 'headquater' => 'Siraha',
                 'area' => 1188
             ],
             [
-                'province_id' => 1,
+                'province_id' => 2,
                 'name' => 'Mahottari',
                 'headquater' => 'Jaleshwar',
                 'area' => 1002
             ],
             [
-                'province_id' => 1,
+                'province_id' => 2,
                 'name' => 'Saptari',
                 'headquater' => 'Rajbiraj',
                 'area' => 1363


### PR DESCRIPTION
Province one is selected in the three districts of province two. As a result, in the province listing there were 17 districts in province one and 5 in province two but 14 and 8 respectively is the correct one. This issue is fixed.