### PR TITLE
Add support for laravel version greater than 7

### DIFF
--- a/database/migrations/2020_10_14_000000_create_provinces_table.php
+++ b/database/migrations/2020_10_14_000000_create_provinces_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Database\Seeders\ProvinceSeeder;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Artisan;
@@ -25,7 +26,7 @@ class CreateProvincesTable extends Migration
         });
 
         // Seeder Artisan Call
-        if (config('laranepal.seeding_while_migration', true)) {
+        if (config('laraNepal.seeding_while_migration', true)) {
             Artisan::call('db:seed', [
                 '--class' => ProvinceSeeder::class,
             ]);

--- a/database/migrations/2020_10_14_000099_create_districts_table.php
+++ b/database/migrations/2020_10_14_000099_create_districts_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Database\Seeders\DistrictSeeder;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Artisan;
@@ -25,7 +26,7 @@ class CreateDistrictsTable extends Migration
         });
 
         // Seeder Artisan Call
-        if (config('laranepal.seeding_while_migration', true)) {
+        if (config('laraNepal.seeding_while_migration', true)) {
             Artisan::call('db:seed', [
                 '--class' => DistrictSeeder::class,
             ]);

--- a/database/migrations/2020_10_14_000100_create_municipalities_table.php
+++ b/database/migrations/2020_10_14_000100_create_municipalities_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use Database\Seeders\MunicipalitySeeder;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Artisan;
@@ -24,7 +25,7 @@ class CreateMunicipalitiesTable extends Migration
         });
 
         // Seeder Artisan Call
-        if (config('laranepal.seeding_while_migration', true)) {
+        if (config('laraNepal.seeding_while_migration', true)) {
             Artisan::call('db:seed', [
                 '--class' => MunicipalitySeeder::class,
             ]);

--- a/database/seeders/DistrictSeeder.php
+++ b/database/seeders/DistrictSeeder.php
@@ -1,6 +1,9 @@
 <?php
 
+namespace Database\Seeders;
+
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 
 class DistrictSeeder extends Seeder
 {

--- a/database/seeders/MunicipalitySeeder.php
+++ b/database/seeders/MunicipalitySeeder.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Database\Seeders;
+
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 

--- a/database/seeders/ProvinceSeeder.php
+++ b/database/seeders/ProvinceSeeder.php
@@ -1,6 +1,9 @@
 <?php
 
+namespace Database\Seeders;
+
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 
 class ProvinceSeeder extends Seeder
 {

--- a/src/LaraNepal.php
+++ b/src/LaraNepal.php
@@ -12,7 +12,7 @@ class LaraNepal
     // Retrive Nepal's Provinces
     public function provinces()
     {
-        $provinces = config('laranepal.caching', true)
+        $provinces = config('laraNepal.caching', true)
             ? (Cache::has('provinces') ? Cache::get('provinces') : Province::with('districts')->get())
             : Province::with('districts')->get();
 
@@ -22,7 +22,7 @@ class LaraNepal
     // Retrives Nepal's Districts
     public function districts()
     {
-        $districts = config('laranepal.caching', true)
+        $districts = config('laraNepal.caching', true)
             ? (Cache::has('districts') ? Cache::get('districts') : District::with('municipalities')->get())
             : District::with('municipalities')->get();
 
@@ -32,7 +32,7 @@ class LaraNepal
     // Retrives Nepal's Municipalities
     public function municipalities()
     {
-        $municipalities = config('laranepal.caching', true)
+        $municipalities = config('laraNepal.caching', true)
             ? (Cache::has('municipalities') ? Cache::get('municipalities') : Municipality::all())
             : Municipality::all();
 

--- a/src/LaraNepalServiceProvider.php
+++ b/src/LaraNepalServiceProvider.php
@@ -69,7 +69,7 @@ class LaraNepalServiceProvider extends ServiceProvider
     protected function publishSeeds()
     {
         $this->publishes([
-            __DIR__.'/../database/seeds' =>  database_path('seeds'),
+            __DIR__.'/../database/seeders' =>  database_path('seeders'),
         ], 'laranepal-seed');
     }
 }


### PR DESCRIPTION
This PR aims to support laravel 8 and laravel 9 by default. 

To do this the following changes are made: 
- [x] Migrate seeders from seed folder to seeder folder
 - [x] Add namespace to Seeders
 - [x] Change config key laranepal to laraNepal in migration and laraNepal facade